### PR TITLE
chore: switch to trunk-based workflow, drop release branches

### DIFF
--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - release/**
 
 jobs:
   commitizen:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ Do not force-add any of these to the repository.
 
 ## Pull Requests
 
-Use the pull request template provided. All checklist items must be addressed before requesting review.
+Branch from `main`, open a PR back to `main`. Use the pull request template provided. All checklist items must be addressed before requesting review.
 
 ## Commit Messages — Conventional Commits
 


### PR DESCRIPTION
## Summary

- Removes `release/v*` branching convention — feature/fix branches now go directly from `main` to `main` via PR
- Updates `CONTRIBUTING.md` with explicit branching instructions
- Narrows commitizen CI trigger to PRs targeting `main` only (was also `release/**`)
- Branch protection ruleset already updated separately (main-only, rebase-only)

## Checklist

- [x] `flake8` errors-only pass is clean
- [x] Tests pass
- [x] No AI tool config files committed
- [x] `CHANGELOG.md` — no functional change, no entry needed
- [x] Conventional commit format