### PR TITLE
feat(ci): publish to PyPI via Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Build
+        run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers on `v*` tag pushes (created by `cz bump`)
- Builds with `poetry build`, publishes with `pypa/gh-action-pypi-publish`
- Uses OIDC Trusted Publishers — no PyPI token secret required

## Before merging

The Trusted Publisher must be configured on PyPI first (one-time setup):

1. Go to https://pypi.org/manage/project/ssss/settings/publishing/
2. Add a new publisher with these values:
   - **Publisher:** GitHub Actions
   - **Owner:** `the-commits`
   - **Repository:** `super-simple-static-site`
   - **Workflow name:** `publish.yml`
   - **Environment name:** `pypi`
3. Create a GitHub environment named `pypi` at https://github.com/the-commits/super-simple-static-site/settings/environments

## Checklist

- [x] flake8 clean
- [x] Tests pass
- [x] No AI tool config files committed
- [x] Conventional commit format