### PR TITLE
fix(ci): exit gracefully when no commits found for cz bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version and update changelog
-        run: cz bump --yes
+        id: bump
+        run: |
+          cz bump --yes && echo "bumped=true" >> $GITHUB_OUTPUT || \
+          { code=$?; [ $code -eq 3 ] && echo "bumped=false" >> $GITHUB_OUTPUT && exit 0 || exit $code; }
 
       - name: Push tag and changelog
+        if: steps.bump.outputs.bumped == 'true'
         run: git push --follow-tags


### PR DESCRIPTION
## Summary

- \`cz bump\` exits with code 3 when there are no new commits since the last tag — this is expected, not an error
- Workflow now treats exit code 3 as a no-op: sets \`bumped=false\` and skips the push step
- All other non-zero exit codes still fail the build

## Checklist

- [x] flake8 clean
- [x] Tests pass
- [x] No AI tool config files committed
- [x] Conventional commit format