### PR TITLE
fix(init): write starter content into scaffold files on --init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `--init` now writes starter content into `default.j2`, `base.html`, and `index.md` instead of creating empty files
+
 ## v1.1.0 (2026-03-05)
 
 ### Feat

--- a/ssss/common/application/variables.py
+++ b/ssss/common/application/variables.py
@@ -8,7 +8,11 @@ def application_name() -> str:
 def application_description() -> str:
     long_description = importlib.metadata.metadata(application_name())["description"]
     short_description = long_description.split(".")[1]
-    return application_name() + " - " + "".join([c for c in short_description if c.isalnum() or c.isspace()])
+    return (
+        application_name()
+        + " - "
+        + "".join([c for c in short_description if c.isalnum() or c.isspace()])
+    )
 
 
 def application_version() -> str:
@@ -66,9 +70,11 @@ def application_default_site() -> dict:
 
 
 def application_default_template_file() -> str:
-    return application_default_template_path() \
-        + application_default_template_name() \
+    return (
+        application_default_template_path()
+        + application_default_template_name()
         + application_default_template_extension()
+    )
 
 
 def application_default_base_html() -> str:
@@ -79,3 +85,32 @@ def application_default_config_data() -> dict:
     return {
         "site": application_default_site(),
     }
+
+
+def application_default_base_html_content() -> str:
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        "  <title>{{ title }}</title>\n"
+        '  <meta name="description" content="{{ description }}">\n'
+        "</head>\n"
+        "<body>\n"
+        "  {% block content %}{% endblock %}\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def application_default_template_file_content() -> str:
+    return (
+        '{% extends "_templates/base.html" %}\n'
+        "{% block content %}\n"
+        "{{ content }}\n"
+        "{% endblock %}\n"
+    )
+
+
+def application_default_index_md_content() -> str:
+    return "# Welcome\n\nThis is your new ssss site.\n"

--- a/ssss/common/fs/__init__.py
+++ b/ssss/common/fs/__init__.py
@@ -1,7 +1,10 @@
-from .directory import make_empty, \
-    have_write_permission, \
-    get_user_home_directory, \
-    get_user_config_directory, \
-    get_current_directory
+from .directory import (
+    make_empty,
+    have_write_permission,
+    get_user_home_directory,
+    get_user_config_directory,
+    get_current_directory,
+)
 
 from .file import find_config
+from .file import write_if_not_exists

--- a/ssss/common/fs/file.py
+++ b/ssss/common/fs/file.py
@@ -19,8 +19,9 @@ def application_config_file_extension() -> list[str]:
 
 def search_config_in_dir(directory) -> str | None:
     for ext in application_config_file_extension():
-        if os.path.exists(directory + "/" + application_name() + ext) and os.path.isfile(
-                directory + "/" + application_name() + ext):
+        if os.path.exists(
+            directory + "/" + application_name() + ext
+        ) and os.path.isfile(directory + "/" + application_name() + ext):
             return os.path.abspath(directory + "/" + application_name() + ext)
     return None
 
@@ -41,3 +42,9 @@ def search_config_in_dirs() -> str | None:
 def touch_if_not_exists(path):
     if not os.path.exists(path):
         Path(path).touch()
+
+
+def write_if_not_exists(path, content):
+    if not os.path.exists(path):
+        with open(path, "w") as file:
+            file.write(content)

--- a/ssss/configuration/application.py
+++ b/ssss/configuration/application.py
@@ -4,19 +4,34 @@ from pathlib import Path
 import yaml
 
 from ssss.common.application import application_default_config_data
-from ssss.common.application.variables import application_default_template_path, application_default_template_file, \
-    application_default_base_html, application_default_source, application_default_output, application_default_data, \
-    application_default_encoding, application_default_followlinks, application_default_filters, application_default_site
+from ssss.common.application.variables import (
+    application_default_template_path,
+    application_default_template_file,
+    application_default_base_html,
+    application_default_source,
+    application_default_output,
+    application_default_data,
+    application_default_encoding,
+    application_default_followlinks,
+    application_default_filters,
+    application_default_site,
+    application_default_base_html_content,
+    application_default_template_file_content,
+    application_default_index_md_content,
+)
 from ssss.common.fs import find_config
-from ssss.common.fs.directory import get_full_path, create_directory_if_not_exists, have_write_permission
-from ssss.common.fs.file import touch_if_not_exists
+from ssss.common.fs.directory import (
+    get_full_path,
+    create_directory_if_not_exists,
+    have_write_permission,
+)
+from ssss.common.fs.file import write_if_not_exists
 from ssss.common.md import variables, render
 from ssss.configuration.arguments import Arguments
 from ssss.configuration.default import config_file_path
 
 
 class Application(Arguments):
-
     def __init__(self):
         self.config = {}
         self.__init_config = None
@@ -37,16 +52,12 @@ class Application(Arguments):
         return self.config
 
     def handle_args(self):
-        self.parse.add_argument(
-            "-c",
-            "--config",
-            help="Path to configuration file"
-        )
+        self.parse.add_argument("-c", "--config", help="Path to configuration file")
         self.parse.add_argument(
             "--init",
             action="store_true",
             help="Initialize configuration file and site structure",
-            default=False
+            default=False,
         )
         args = self.parse.parse_args()
 
@@ -80,14 +91,30 @@ class Application(Arguments):
 
     def set_config(self):
         self.data = {k: v for k, v in self.data.items() if v}
-        self.config["searchpath"] = get_full_path(self.data.get("source", application_default_source()))
-        self.config["outpath"] = get_full_path(self.data.get("output", application_default_output()))
-        self.config["contexts"] = [(self.data.get("data", application_default_data()), variables)]
-        self.config["rules"] = [(self.data.get("data", application_default_data()), render.run)]
-        self.config["encoding"] = str(self.data.get("encoding", application_default_encoding()))
-        self.config["followlinks"] = str(self.data.get("followlinks", application_default_followlinks()))
-        self.config["filters"] = dict(self.data.get("filters", application_default_filters()))
-        self.config["env_globals"] = dict(self.data.get("site", application_default_site()))
+        self.config["searchpath"] = get_full_path(
+            self.data.get("source", application_default_source())
+        )
+        self.config["outpath"] = get_full_path(
+            self.data.get("output", application_default_output())
+        )
+        self.config["contexts"] = [
+            (self.data.get("data", application_default_data()), variables)
+        ]
+        self.config["rules"] = [
+            (self.data.get("data", application_default_data()), render.run)
+        ]
+        self.config["encoding"] = str(
+            self.data.get("encoding", application_default_encoding())
+        )
+        self.config["followlinks"] = str(
+            self.data.get("followlinks", application_default_followlinks())
+        )
+        self.config["filters"] = dict(
+            self.data.get("filters", application_default_filters())
+        )
+        self.config["env_globals"] = dict(
+            self.data.get("site", application_default_site())
+        )
 
     def init_config(self):
 
@@ -113,28 +140,20 @@ class Application(Arguments):
         create_directory_if_not_exists(self.config["searchpath"])
 
         create_directory_if_not_exists(
-            os.path.join(
-                self.config["searchpath"],
-                application_default_template_path()
-            )
+            os.path.join(self.config["searchpath"], application_default_template_path())
         )
 
-        touch_if_not_exists(
-            os.path.join(self.config["searchpath"],
-                         application_default_base_html()
-                         )
+        write_if_not_exists(
+            os.path.join(self.config["searchpath"], application_default_base_html()),
+            application_default_base_html_content(),
         )
-        touch_if_not_exists(
+        write_if_not_exists(
             os.path.join(
-                self.config["searchpath"],
-                application_default_template_file()
-            )
+                self.config["searchpath"], application_default_template_file()
+            ),
+            application_default_template_file_content(),
         )
-        touch_if_not_exists(
-            os.path.join(
-                os.path.join(
-                    self.config["searchpath"],
-                    "index.md"
-                )
-            )
+        write_if_not_exists(
+            os.path.join(os.path.join(self.config["searchpath"], "index.md")),
+            application_default_index_md_content(),
         )

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,6 +1,8 @@
+import os
 import unittest
 
 from ssss.common.fs.directory import get_full_path, get_current_directory
+from ssss.common.fs.file import write_if_not_exists
 
 
 class Fullpath(unittest.TestCase):
@@ -13,5 +15,25 @@ class Fullpath(unittest.TestCase):
         self.assertEqual(get_current_directory(), path)
 
 
-if __name__ == '__main__':
+class WriteIfNotExists(unittest.TestCase):
+    def test_creates_file_with_content(self):
+        path = "/tmp/test_write_if_not_exists.txt"
+        if os.path.exists(path):
+            os.unlink(path)
+        write_if_not_exists(path, "hello")
+        with open(path, "r") as f:
+            self.assertEqual(f.read(), "hello")
+        os.unlink(path)
+
+    def test_does_not_overwrite_existing_file(self):
+        path = "/tmp/test_write_if_not_exists_existing.txt"
+        with open(path, "w") as f:
+            f.write("original")
+        write_if_not_exists(path, "new content")
+        with open(path, "r") as f:
+            self.assertEqual(f.read(), "original")
+        os.unlink(path)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ssss.py
+++ b/tests/test_ssss.py
@@ -2,6 +2,11 @@ import os
 import subprocess
 from os import unlink
 
+from ssss.common.application.variables import (
+    application_default_base_html_content,
+    application_default_template_file_content,
+    application_default_index_md_content,
+)
 from ssss.common.fs import make_empty
 from ssss.common.fs.file import touch_if_not_exists
 
@@ -20,24 +25,30 @@ def test_ssss_no_args():
 def test_ssss_no_args_after_init():
     output, returncode = run_ssss("--init", "-c", "test.yml")
     assert returncode == 0
-    assert "Looking at: _templates/__index.j2, using default template: _templates/default.j2" in output
+    assert (
+        "Looking at: _templates/__index.j2, using default template: _templates/default.j2"
+        in output
+    )
 
     output, returncode = run_ssss("-c", "test.yml")
     assert returncode == 0
-    assert "Looking at: _templates/__index.j2, using default template: _templates/default.j2" in output
+    assert (
+        "Looking at: _templates/__index.j2, using default template: _templates/default.j2"
+        in output
+    )
 
-    unlink('test.yml')
-    make_empty('site', True)
+    unlink("test.yml")
+    make_empty("site", True)
 
 
 def test_ssss_no_args_after_init_with_empty_config():
-    touch_if_not_exists('test.yml')
+    touch_if_not_exists("test.yml")
     output, returncode = run_ssss("-c", "test.yml")
 
     assert returncode == 1
     assert "Configuration file is empty." in output
 
-    unlink('test.yml')
+    unlink("test.yml")
 
 
 def test_ssss_short_help():
@@ -56,13 +67,13 @@ def test_ssss_init():
     output, returncode = run_ssss("--init")
     assert returncode == 0
 
-    with open('ssss.yml', 'r') as f:
+    with open("ssss.yml", "r") as f:
         actual_contents = f.read()
 
-    with open('tests/data/ssss.yml', 'r') as f:
+    with open("tests/data/ssss.yml", "r") as f:
         expected_contents = f.read()
 
-    unlink('ssss.yml')
+    unlink("ssss.yml")
 
     assert actual_contents == expected_contents
 
@@ -71,13 +82,13 @@ def test_ssss_init_with_config():
     output, returncode = run_ssss("--init", "--config", "custom_config.yaml")
     assert returncode == 0
 
-    with open('custom_config.yaml', 'r') as f:
+    with open("custom_config.yaml", "r") as f:
         actual_contents = f.read()
 
-    with open('tests/data/ssss.yml', 'r') as f:
+    with open("tests/data/ssss.yml", "r") as f:
         expected_contents = f.read()
 
-    unlink('custom_config.yaml')
+    unlink("custom_config.yaml")
 
     assert actual_contents == expected_contents
 
@@ -86,12 +97,29 @@ def test_ssss_init_file_structure():
     output, returncode = run_ssss("--init")
     assert returncode == 0
 
-    site_exists = os.path.exists('site')
-    source_exists = os.path.exists('site/source/index.md')
-    template_exists = os.path.exists('site/source/_templates/default.j2')
-    base_exists = os.path.exists('site/source/_templates/base.html')
-    data_exists = os.path.exists('site/build/index.html')
+    site_exists = os.path.exists("site")
+    source_exists = os.path.exists("site/source/index.md")
+    template_exists = os.path.exists("site/source/_templates/default.j2")
+    base_exists = os.path.exists("site/source/_templates/base.html")
+    data_exists = os.path.exists("site/build/index.html")
 
-    unlink('ssss.yml')
-    make_empty('site', True)
-    assert site_exists and source_exists and template_exists and base_exists and data_exists
+    with open("site/source/index.md", "r") as f:
+        index_md_content = f.read()
+    with open("site/source/_templates/default.j2", "r") as f:
+        template_content = f.read()
+    with open("site/source/_templates/base.html", "r") as f:
+        base_html_content = f.read()
+
+    unlink("ssss.yml")
+    make_empty("site", True)
+
+    assert (
+        site_exists
+        and source_exists
+        and template_exists
+        and base_exists
+        and data_exists
+    )
+    assert index_md_content == application_default_index_md_content()
+    assert template_content == application_default_template_file_content()
+    assert base_html_content == application_default_base_html_content()


### PR DESCRIPTION
## Summary

- `--init` was creating empty `default.j2`, `base.html`, and `index.md` files via `Path.touch()`, causing `ssss --init` to produce an empty `index.html`
- Replaced `touch_if_not_exists` with a new `write_if_not_exists(path, content)` helper in `fs/file.py`
- Added three `application_default_*_content()` functions in `variables.py` providing minimal working starter content for each scaffold file
- Updated `test_ssss_init_file_structure` to assert file contents (not just existence), and added unit tests for `write_if_not_exists`
- All 12 tests pass; lint clean; no coverage regression (8 missing lines, same as before)

## Checklist

- [x] Tests added/updated
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Lint passes (`flake8` errors: 0)
- [x] Coverage not regressed (97% → 97%)