### PR TITLE
feat(ci): upload coverage to Codecov and add badge to README

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,4 +43,9 @@ jobs:
         run: |
           poetry install
           poetry build
-          poetry run pytest --cov=ssss
+          poetry run pytest --cov=ssss --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![example workflow](https://github.com/the-commits/super-simple-static-site/actions/workflows/python-package.yml/badge.svg)
+[![codecov](https://codecov.io/gh/the-commits/super-simple-static-site/graph/badge.svg)](https://codecov.io/gh/the-commits/super-simple-static-site)
 # Super Simple Static Site (ssss)
 
 ssss, short for Super Simple Static Site, is a static site generator that leverages Jinja and Markdown for creating


### PR DESCRIPTION
## Description

Integrates Codecov for dynamic, auto-updating test coverage reporting:

- Updates `python-package.yml` to generate `coverage.xml` and upload it to Codecov via `codecov/codecov-action@v4` on every CI run
- Adds the Codecov badge to `README.md` alongside the existing CI badge

The Codecov badge will display the current coverage percentage and auto-update on every merge to `main`. No token required for public repositories.

## Type of change

- [x] New feature

## Checklist

- [x] `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` passes with zero errors
- [x] `poetry run pytest --cov=ssss` passes with 100% coverage
- [x] New code follows the style guide in `CONTRIBUTING.md`
- [x] No AI tool config files or instruction files are included (see `.gitignore`)
- [x] Tests clean up any files or directories they create