### PR TITLE
chore(ci): update Codecov upload to v5 with token and enable branch coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,9 +43,8 @@ jobs:
         run: |
           poetry install
           poetry build
-          poetry run pytest --cov=ssss --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+          poetry run pytest --cov=ssss --cov-branch --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          files: coverage.xml
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Configures Codecov correctly using the setup instructions from the Codecov dashboard:

- Upgrades `codecov/codecov-action` from `v4` to `v5`
- Adds `token: ${{ secrets.CODECOV_TOKEN }}` for authenticated uploads (token added as repo secret)
- Adds `--cov-branch` to pytest flags to include branch coverage in the report
- Removes the now-unnecessary explicit `files: coverage.xml` and `fail_ci_if_error` options (v5 defaults handle these)

## Type of change

- [x] Other

## Checklist

- [x] `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` passes with zero errors
- [x] `poetry run pytest --cov=ssss` passes with 100% coverage
- [x] New code follows the style guide in `CONTRIBUTING.md`
- [x] No AI tool config files or instruction files are included (see `.gitignore`)
- [x] Tests clean up any files or directories they create