### PR TITLE
feat(cli): add --version / -v flag

### DIFF
--- a/ssss/configuration/application.py
+++ b/ssss/configuration/application.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 
-from ssss.common.application import application_default_config_data
+from ssss.common.application import application_default_config_data, application_version
 from ssss.common.application.variables import (
     application_default_template_path,
     application_default_template_file,
@@ -55,6 +55,12 @@ class Application(Arguments):
             action="store_true",
             help="Initialize configuration file and site structure",
             default=False,
+        )
+        self.parse.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version=application_version(),
         )
         args = self.parse.parse_args()
 

--- a/tests/test_ssss.py
+++ b/tests/test_ssss.py
@@ -23,6 +23,18 @@ def test_ssss_no_args():
     assert "No configuration file found" in output
 
 
+def test_ssss_version():
+    output, returncode = run_ssss("--version")
+    assert returncode == 0
+    assert "ssss" in output
+
+
+def test_ssss_short_version():
+    output, returncode = run_ssss("-v")
+    assert returncode == 0
+    assert "ssss" in output
+
+
 def test_ssss_no_args_after_init():
     output, returncode = run_ssss("--init", "-c", "test.yml")
     assert returncode == 0


### PR DESCRIPTION
## Description

Adds `--version` and `-v` flags to the CLI using argparse's built-in `action="version"`. Prints the version string from package metadata and exits cleanly with code 0.

```
$ ssss --version
ssss 1.1.0
$ ssss -v
ssss 1.1.0
```

## Type of change

- [x] New feature

## Checklist

- [x] `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` passes with zero errors
- [x] `poetry run pytest --cov=ssss` passes with 100% coverage
- [x] New code follows the style guide in `CONTRIBUTING.md`
- [x] No AI tool config files or instruction files are included (see `.gitignore`)
- [x] Tests clean up any files or directories they create