### PR TITLE
feat(scaffold): add Pico CSS CDN to base.html template

### DIFF
--- a/ssss/common/application/variables.py
+++ b/ssss/common/application/variables.py
@@ -93,11 +93,15 @@ def application_default_base_html_content() -> str:
         '<html lang="en">\n'
         "<head>\n"
         '  <meta charset="utf-8">\n'
+        '  <meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        '  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.1.1/css/pico.min.css">\n'
         "  <title>{{ title }}</title>\n"
         '  <meta name="description" content="{{ description }}">\n'
         "</head>\n"
         "<body>\n"
-        "  {% block content %}{% endblock %}\n"
+        '  <main class="container">\n'
+        "    {% block content %}{% endblock %}\n"
+        "  </main>\n"
         "</body>\n"
         "</html>\n"
     )
@@ -113,4 +117,8 @@ def application_default_template_file_content() -> str:
 
 
 def application_default_index_md_content() -> str:
-    return "# Welcome\n\nThis is your new ssss site.\n"
+    return (
+        "# Welcome\n\n"
+        "This is your new **ssss** site.\n\n"
+        "Edit `site/source/index.md` to get started.\n"
+    )


### PR DESCRIPTION
## Description

Adds [Pico CSS](https://picocss.com) (v2.1.1) to the scaffold `base.html` template via CDN. No build step required — pure semantic HTML gets styled automatically.

Changes:
- `base.html`: adds `viewport` meta tag, Pico CSS CDN link, wraps content in `<main class="container">`
- `index.md`: slightly improved starter content with bold and a hint to edit the file

## Type of change

- [x] New feature

## Checklist

- [x] `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` passes with zero errors
- [x] `poetry run pytest --cov=ssss` passes with 100% coverage
- [x] New code follows the style guide in `CONTRIBUTING.md`
- [x] No AI tool config files or instruction files are included (see `.gitignore`)
- [x] Tests clean up any files or directories they create